### PR TITLE
feat(security): add mongoose:readonly tag to prevent mass assignment

### DIFF
--- a/mutation.go
+++ b/mutation.go
@@ -289,6 +289,13 @@ func (m *Model[M]) serializeData(data *M, mutation string) ([]bson.E, error) {
 			nameTag := field.Tag.Get("bson")
 			name := field.Type.Name()
 			val := ct.Field(i).Interface()
+
+			// Skip readonly fields during update/replace to prevent mass assignment
+			mongooseTag := field.Tag.Get("mongoose")
+			if mongooseTag == "readonly" && mutation != "insert" {
+				continue
+			}
+
 			if nameTag != "" && name != "BaseSchema" && !reflect.ValueOf(val).IsZero() {
 				upsert = append(upsert, bson.E{
 					Key:   nameTag,


### PR DESCRIPTION
- Add mongoose:"readonly" tag check in serializeData
- Fields with this tag are skipped during update/replace operations
- Insert operations still include readonly fields (initial values)
- Add Test_ReadonlyTag integration test

Closes #71